### PR TITLE
Specify start for sent_id and sentence type

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pyinstaller -n xml2conllu.exe -F .\xml2conllu.py
 The application can be executed from command-line without GUI. To do so, use the following command:
 
 ``` shell
-xml2conllu.exe --no-window --xml-file <xml-file-path> --postag-file <postag-file-path> --conllu-file <conllu-file-path> [--sent-id-start <integer-value>]
+xml2conllu.exe --no-window --xml-file <xml-file-path> --postag-file <postag-file-path> --conllu-file <conllu-file-path> [--sent-id-start <integer-value>] [--sentence-type train|test]
 ```
 
 To see what each parameter is doing, type:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pyinstaller -n xml2conllu.exe -F .\xml2conllu.py
 The application can be executed from command-line without GUI. To do so, use the following command:
 
 ``` shell
-xml2conllu.exe --no-window --xml-file <xml-file-path> --postag-file <postag-file-path> --conllu-file <conllu-file-path> [--use-input-sentence-id]
+xml2conllu.exe --no-window --xml-file <xml-file-path> --postag-file <postag-file-path> --conllu-file <conllu-file-path> [--sent-id-start <integer-value>]
 ```
 
 To see what each parameter is doing, type:

--- a/src/application.py
+++ b/src/application.py
@@ -84,7 +84,9 @@ class Application(Frame):
         xml_filename = self.xml_input.get()
         postag_filename = self.postag_input.get()
         conllu_filename = self.conllu_output.get()
-
+        is_valid, sent_id_start = self.get_sent_id_input()
+        if not is_valid:
+            return
         full_text = "Success!"
         try:
             errors = self.convert_callback(
@@ -97,14 +99,36 @@ class Application(Frame):
         except Exception as err:
             full_text = "\n".join(["Fatal error!", str(err)])
 
+        self.display_message(full_text)
+
+    def display_message(self, message, title="Conversion output"):
         status_window = Toplevel(self)
-        status_window.wm_title("Convert output!")
+        status_window.wm_title(title)
 
         text = Text(status_window, width=100, height=20)
-        text.insert(END, full_text)
+        text.insert(END, message)
         text.pack()
 
         quit = Button(status_window,
                       text="Close",
                       command=status_window.destroy)
         quit.pack()
+
+    def get_sent_id_input(self):
+        """
+        Validates the input of start_id and returns it.
+
+        Returns
+        -------
+        (is_valid, sent_id_start)
+            A tuple specifying whether input is valid and its value.
+            If input is invalid the return wil bee (False, None);
+            otherwise (True, sent_id_start) will be returned.
+        """
+        try:
+            sent_id_start = int(self.start_id_input.get())
+            return True, sent_id_start
+        except Exception:
+            self.display_message('Please specify a valid integer value.',
+                                 title="Validation error.")
+            return False, None

--- a/src/application.py
+++ b/src/application.py
@@ -1,6 +1,8 @@
 from tkinter import filedialog, Frame, Button, Entry, Label, END
 from tkinter import Toplevel
 from tkinter import Text
+from tkinter import Radiobutton
+from tkinter import StringVar
 
 
 class Application(Frame):
@@ -8,6 +10,7 @@ class Application(Frame):
         Frame.__init__(self, master)
         self.convert_callback = convert_callback
         self.create_widgets(master)
+        self.set_default_values()
 
     def create_widgets(self, master):
         # ## XML Input ## #
@@ -40,19 +43,41 @@ class Application(Frame):
             .grid(row=2, column=2)
         # ## END ## #
 
-        # ## Input ids checkbox ## #
+        # ## Start sent_id widgets ## #
         Label(master, text="Start sent_id at:").grid(row=3, column=0)
         self.start_id_input = Entry(master)
         self.start_id_input.grid(row=3, column=1)
-        self.start_id_input.insert(0, "1")
+        # ## END ## #
+
+        # ## Sentence type widgets ## #
+        Label(master, text="Sentence type:").grid(row=4, column=0)
+        self.sentence_type = StringVar()
+        self.train_rb = Radiobutton(master,
+                                    text="Train",
+                                    variable=self.sentence_type,
+                                    value='train')
+        self.train_rb.grid(row=4, column=1, sticky='W')
+        self.test_rb = Radiobutton(master,
+                                   text="Test",
+                                   variable=self.sentence_type,
+                                   value='test')
+        self.test_rb.grid(row=5, column=1, sticky='W')
+
         # ## END ## #
 
         # ## Convert button ## #
         self.convert_button = Button(master,
                                      text='Convert!',
                                      command=self.convert)
-        self.convert_button.grid(row=4, column=1)
+        self.convert_button.grid(row=6, column=1)
         # ## END ## #
+
+    def set_default_values(self):
+        """
+        Sets default values for input widgets.
+        """
+        self.start_id_input.insert(0, '1')
+        self.train_rb.select()
 
     def ask_open_postag_file(self):
         filename = filedialog.askopenfilename(initialdir="./",
@@ -89,10 +114,12 @@ class Application(Frame):
             return
         full_text = "Success!"
         try:
-            errors = self.convert_callback(xml_filename,
-                                           conllu_filename,
-                                           postag_filename,
-                                           sent_id_start=sent_id_start)
+            errors = self.convert_callback(
+                xml_filename,
+                conllu_filename,
+                postag_filename,
+                sent_id_start=sent_id_start,
+                sentence_type=self.sentence_type.get())
             if errors:
                 full_text = "\n".join(map(lambda x: x.msg, errors))
         except Exception as err:

--- a/src/application.py
+++ b/src/application.py
@@ -1,8 +1,6 @@
 from tkinter import filedialog, Frame, Button, Entry, Label, END
 from tkinter import Toplevel
 from tkinter import Text
-from tkinter import Checkbutton
-from tkinter import IntVar
 
 
 class Application(Frame):
@@ -43,14 +41,10 @@ class Application(Frame):
         # ## END ## #
 
         # ## Input ids checkbox ## #
-        self.use_input_ids = IntVar()
-        self.use_input_ids_chk = Checkbutton(
-            master,
-            text="Use sentece ids from input file",
-            onvalue=1,
-            offvalue=0,
-            variable=self.use_input_ids)
-        self.use_input_ids_chk.grid(row=3, column=1)
+        Label(master, text="Start sent_id at:").grid(row=3, column=0)
+        self.start_id_input = Entry(master)
+        self.start_id_input.grid(row=3, column=1)
+        self.start_id_input.insert(0, "1")
         # ## END ## #
 
         # ## Convert button ## #

--- a/src/application.py
+++ b/src/application.py
@@ -89,11 +89,10 @@ class Application(Frame):
             return
         full_text = "Success!"
         try:
-            errors = self.convert_callback(
-                xml_filename,
-                conllu_filename,
-                postag_filename,
-                sent_id_from_input=self.use_input_ids.get())
+            errors = self.convert_callback(xml_filename,
+                                           conllu_filename,
+                                           postag_filename,
+                                           sent_id_start=sent_id_start)
             if errors:
                 full_text = "\n".join(map(lambda x: x.msg, errors))
         except Exception as err:

--- a/src/xml2conllu.py
+++ b/src/xml2conllu.py
@@ -49,7 +49,10 @@ class ConvertError(Exception):
         return self.msg
 
 
-def convert2conllu(xml_content, postag_data=None, sent_id_start=1):
+def convert2conllu(xml_content,
+                   postag_data=None,
+                   sent_id_start=1,
+                   sentence_type='train'):
     """
     Converts the XML content to CoNLL-U using specified POS tags.
 
@@ -63,6 +66,9 @@ def convert2conllu(xml_content, postag_data=None, sent_id_start=1):
     sent_id_start: integer, optional
         Specifies the start value for sent_id attribute.
         Default is 1.
+    sentence_type: string, optional
+        Specifies the type of sentences. Values are 'train' and 'test'.
+        Default is 'train'.
 
     Returns
     -------
@@ -145,10 +151,11 @@ def convert2conllu(xml_content, postag_data=None, sent_id_start=1):
             word_conllu_lines.append(word_conllu_line)
 
         # Print the sentence
-        conllu_output += '# sent_id = test-%s\n' % sentence_id
-        conllu_output += '# text = %s\n' % sentence
+        conllu_output += '# sent_id = {}-{}\n'.format(sentence_type,
+                                                      sentence_id)
+        conllu_output += '# text = {}\n'.format(sentence)
         if citation_part:
-            conllu_output += '# citation-part=%s\n' % citation_part
+            conllu_output += '# citation-part={}\n'.format(citation_part)
         conllu_output += "\n".join(word_conllu_lines)
         conllu_output += '\n\n'
 

--- a/src/xml2conllu.py
+++ b/src/xml2conllu.py
@@ -172,7 +172,11 @@ def split_with_positions(string):
     return results
 
 
-def convert(xml_file, conllu_file, postag_file, sent_id_start=1):
+def convert(xml_file,
+            conllu_file,
+            postag_file,
+            sent_id_start=1,
+            sentence_type='train'):
     """
     Reads the content of input files and prerforms conversion.
 
@@ -187,6 +191,9 @@ def convert(xml_file, conllu_file, postag_file, sent_id_start=1):
     sent_id_start: integer, optional
         Specifies the start value for sent_id attribute.
         Default is 1.
+    sentence_type: string, optional
+        Specifies the type of sentences. Values are 'train' and 'test'.
+        Default is 'train'.
     """
     postag_data = {}
     with open(postag_file, 'r') as fposttag:
@@ -206,7 +213,8 @@ def convert(xml_file, conllu_file, postag_file, sent_id_start=1):
 
         conllu_data, errors = convert2conllu(xml_content,
                                              postag_data=postag_data,
-                                             sent_id_start=sent_id_start)
+                                             sent_id_start=sent_id_start,
+                                             sentence_type=sentence_type)
 
         with open(conllu_file, 'w', encoding='utf-8') as fconllu:
             fconllu.write(conllu_data)
@@ -235,6 +243,10 @@ def parse_arguments():
         type=int,
         default=1,
         required=False)
+    parser.add_argument('--sentence-type',
+                        help="Specifies the type of the sentece to output.",
+                        choices=['train', 'test'],
+                        default='train')
 
     return parser.parse_args()
 
@@ -245,7 +257,8 @@ if __name__ == '__main__':
         convert(args.xml_file,
                 args.conllu_file,
                 args.postag_file,
-                sent_id_start=args.sent_id_start)
+                sent_id_start=args.sent_id_start,
+                sentence_type=args.sentence_type)
     else:
         from application import Application
         from tkinter import Tk


### PR DESCRIPTION
----

Added possibility to specify the start value for `sent_id` attribute and sentence type shown in the output as `sent_id=<sentence-type>-<sentence-id>`.

Resolves #7.